### PR TITLE
Take into account foreground alpha for contrast

### DIFF
--- a/src/lib/components/colors/Header.svelte
+++ b/src/lib/components/colors/Header.svelte
@@ -9,12 +9,16 @@
   export let type: 'bg' | 'fg';
   export let color: Writable<PlainColorObject>;
   export let format: ColorFormatId;
+  export let premultipliedFg: PlainColorObject | null;
 
   $: targetSpace = getSpaceFromFormatId(format);
   $: display = serialize($color, { inGamut: false, format });
   $: displayType = type === 'bg' ? 'Background' : 'Foreground';
   $: editing = false;
   $: inputValue = '';
+  $: displayPremultipliedFg = premultipliedFg
+    ? serialize(premultipliedFg, { inGamut: false, format })
+    : '';
   let hasError = false;
 
   // When not editing, sync input value with color (e.g. when sliders change)
@@ -89,6 +93,15 @@
   {#if hasError}
     <div data-color-info="warning">Could not parse input as a valid color.</div>
   {/if}
+  {#if premultipliedFg}
+    <div
+      data-color-info="premultiplied"
+      style="--premultipliedFg:{serialize(premultipliedFg)}"
+    >
+      {displayPremultipliedFg}
+      <span class="premultipliedFg"></span>
+    </div>
+  {/if}
 </div>
 
 <style lang="scss">
@@ -151,6 +164,14 @@
       border-radius: 0 var(--border-radius) var(--border-radius) 0;
       z-index: -1;
     }
+  }
+
+  .premultipliedFg {
+    background-color: var(--premultipliedFg);
+    width: 10pt;
+    height: 10pt;
+    border: 1pt solid black;
+    display: inline-block;
   }
 
   [data-input='color'] {

--- a/src/lib/components/colors/index.svelte
+++ b/src/lib/components/colors/index.svelte
@@ -3,7 +3,7 @@
   import Header from '$lib/components/colors/Header.svelte';
   import Sliders from '$lib/components/colors/Sliders.svelte';
   import SupportWarning from '$lib/components/colors/SupportWarning.svelte';
-  import { bg, fg, format } from '$lib/stores';
+  import { bg, fg, format, premultipliedFg } from '$lib/stores';
 </script>
 
 <h2 class="sr-only">Check the contrast ratio between two colors</h2>
@@ -11,10 +11,15 @@
 <SupportWarning format={$format} />
 
 <form data-form="contrast-checker" data-layout="color-form">
-  <Header type="bg" color={bg} format={$format} />
+  <Header type="bg" color={bg} format={$format} premultipliedFg={null} />
   <Sliders type="bg" color={bg} format={$format} />
 
-  <Header type="fg" color={fg} format={$format} />
+  <Header
+    type="fg"
+    color={fg}
+    format={$format}
+    premultipliedFg={$premultipliedFg}
+  />
   <Sliders type="fg" color={fg} format={$format} />
 </form>
 

--- a/src/lib/components/ratio/index.svelte
+++ b/src/lib/components/ratio/index.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-  import { clone, contrast } from 'colorjs.io/fn';
+  import { clone, contrast, serialize } from 'colorjs.io/fn';
 
   import Result from '$lib/components/ratio/Result.svelte';
   import ExternalLink from '$lib/components/util/ExternalLink.svelte';
   import { RATIOS } from '$lib/constants';
-  import { bg, premultipliedFg } from '$lib/stores';
+  import { bg, fg, premultipliedFg } from '$lib/stores';
 
   let ratio: number;
 
@@ -33,6 +33,13 @@
         >Learn more about contrast ratio requirements.</ExternalLink
       >
     </p>
+  </div>
+
+  <div class="compare-alpha">
+    <div style="--alpha-color:{serialize($fg)}">With alpha</div>
+    <div style="--alpha-color:{serialize($premultipliedFg)}">
+      Alpha premultipled
+    </div>
   </div>
 
   <div class="result-status">
@@ -160,6 +167,16 @@
   .contrast-defined {
     @include config.below('lg-page-break') {
       display: none;
+    }
+  }
+  .compare-alpha {
+    display: flex;
+    color: black;
+    > div {
+      background-color: var(--alpha-color);
+      height: 4em;
+      border: 1pt solid white;
+      flex: auto;
     }
   }
 </style>

--- a/src/lib/components/ratio/index.svelte
+++ b/src/lib/components/ratio/index.svelte
@@ -11,7 +11,8 @@
   $: {
     const bgNoAlpha = clone($bg);
     bgNoAlpha.alpha = 1;
-    ratio = contrast(bgNoAlpha, $premultipliedFg, 'WCAG21');
+
+    ratio = contrast(bgNoAlpha, $premultipliedFg || $fg, 'WCAG21');
   }
   $: displayRatio = Math.round((ratio + Number.EPSILON) * 100) / 100;
   $: pass = ratio >= RATIOS.AA.Large;
@@ -35,12 +36,16 @@
     </p>
   </div>
 
-  <div class="compare-alpha">
-    <div style="--alpha-color:{serialize($fg)}">With alpha</div>
-    <div style="--alpha-color:{serialize($premultipliedFg)}">
-      Alpha premultipled
+  {#if $premultipliedFg}
+    Because WCAG 2 doesn't account for alpha, this is approximated by
+    premultiplying the foreground color in the sRGB space.
+    <div class="compare-alpha">
+      <div style="--alpha-color:{serialize($fg)}">With alpha</div>
+      <div style="--alpha-color:{serialize($premultipliedFg)}">
+        Alpha premultipled
+      </div>
     </div>
-  </div>
+  {/if}
 
   <div class="result-status">
     <Result level="AA" type="Normal" {ratio} />

--- a/src/lib/components/ratio/index.svelte
+++ b/src/lib/components/ratio/index.svelte
@@ -1,12 +1,18 @@
 <script lang="ts">
-  import { contrast } from 'colorjs.io/fn';
+  import { clone, contrast, serialize } from 'colorjs.io/fn';
 
   import Result from '$lib/components/ratio/Result.svelte';
   import ExternalLink from '$lib/components/util/ExternalLink.svelte';
   import { RATIOS } from '$lib/constants';
-  import { bg, fg } from '$lib/stores';
+  import { bg, premultipliedFg } from '$lib/stores';
 
-  $: ratio = contrast($bg, $fg, 'WCAG21');
+  let ratio: number;
+
+  $: {
+    const bgNoAlpha = clone($bg);
+    bgNoAlpha.alpha = 1;
+    ratio = contrast(bgNoAlpha, $premultipliedFg, 'WCAG21');
+  }
   $: displayRatio = Math.round((ratio + Number.EPSILON) * 100) / 100;
   $: pass = ratio >= RATIOS.AA.Large;
 </script>
@@ -38,7 +44,7 @@
 
   <div class="contrast-defined">
     <h4 class="label">AA Contrast Ratio</h4>
-
+    {serialize($premultipliedFg)}
     <dl>
       <dt><strong>{RATIOS.AA.Normal}</strong> : 1</dt>
       <dd>Normal Text</dd>

--- a/src/lib/components/ratio/index.svelte
+++ b/src/lib/components/ratio/index.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { clone, contrast, serialize } from 'colorjs.io/fn';
+  import { clone, contrast } from 'colorjs.io/fn';
 
   import Result from '$lib/components/ratio/Result.svelte';
   import ExternalLink from '$lib/components/util/ExternalLink.svelte';
@@ -44,7 +44,6 @@
 
   <div class="contrast-defined">
     <h4 class="label">AA Contrast Ratio</h4>
-    {serialize($premultipliedFg)}
     <dl>
       <dt><strong>{RATIOS.AA.Normal}</strong> : 1</dt>
       <dd>Normal Text</dd>

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -10,11 +10,13 @@ import {
   sRGB,
 } from 'colorjs.io/fn';
 import type { PlainColorObject } from 'colorjs.io/types/src/color';
-import { writable } from 'svelte/store';
+import { derived, writable } from 'svelte/store';
 
 // eslint-disable-next-line import/no-unresolved
 import { browser, dev } from '$app/environment';
 import type { ColorFormatId } from '$lib/constants';
+
+import { premultiplyFG } from './utils';
 
 // Register supported color spaces
 ColorSpace.register(HSL);
@@ -51,6 +53,7 @@ const INITIAL_FG = {
 export const format = writable<ColorFormatId>(INITIAL_VALUES.format);
 export const bg = writable<PlainColorObject>(INITIAL_BG);
 export const fg = writable<PlainColorObject>(INITIAL_FG);
+export const premultipliedFg = derived([fg, bg, format], premultiplyFG);
 
 export const reset = () => {
   bg.set(INITIAL_BG);

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -7,6 +7,10 @@ import { FORMATS } from '$lib/constants';
 export const getSpaceFromFormatId = (formatId: ColorFormatId) =>
   formatId === 'hex' ? 'srgb' : formatId;
 
+// hsl should be mixed in the srgb space for a more uniform hue gradient
+export const getMixSpaceFromFormatId = (formatId: ColorFormatId) =>
+  ['hex', 'hsl'].includes(formatId) ? 'srgb' : formatId;
+
 export const sliderGradient = (
   color: PlainColorObject,
   channel: string,
@@ -98,11 +102,9 @@ export const premultiplyFG = ([fg, bg, format]: [
   bgNoAlpha.alpha = 1;
   const fgNoAlpha = clone(fg);
   fgNoAlpha.alpha = 1;
-  const space = getSpaceFromFormatId(format);
+  const space = getMixSpaceFromFormatId(format);
   return mix(fgNoAlpha, bgNoAlpha, 1 - fg.alpha, {
-    // Mix in oklch for more consistent adjustments
-    // This does not match https://www.w3.org/TR/compositing-1/#simplealphacompositing
-    space: 'oklch',
+    space,
     outputSpace: space,
   });
 };

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -94,6 +94,7 @@ export const premultiplyFG = ([fg, bg, format]: [
   bg: PlainColorObject,
   format: ColorFormatId,
 ]) => {
+  if (fg.alpha === 1) return;
   const bgNoAlpha = clone(bg);
   bgNoAlpha.alpha = 1;
   const fgNoAlpha = clone(fg);

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -103,6 +103,6 @@ export const premultiplyFG = ([fg, bg, format]: [
     // We always mix in srgb, as we are approximating the color as it will be
     // displayed on a monitor.
     space: 'srgb',
-    outputSpace: format,
+    outputSpace: getSpaceFromFormatId(format),
   });
 };

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -7,10 +7,6 @@ import { FORMATS } from '$lib/constants';
 export const getSpaceFromFormatId = (formatId: ColorFormatId) =>
   formatId === 'hex' ? 'srgb' : formatId;
 
-// hsl should be mixed in the srgb space for a more uniform hue gradient
-export const getMixSpaceFromFormatId = (formatId: ColorFormatId) =>
-  ['hex', 'hsl'].includes(formatId) ? 'srgb' : formatId;
-
 export const sliderGradient = (
   color: PlainColorObject,
   channel: string,
@@ -102,9 +98,11 @@ export const premultiplyFG = ([fg, bg, format]: [
   bgNoAlpha.alpha = 1;
   const fgNoAlpha = clone(fg);
   fgNoAlpha.alpha = 1;
-  const space = getMixSpaceFromFormatId(format);
+
   return mix(fgNoAlpha, bgNoAlpha, 1 - fg.alpha, {
-    space,
-    outputSpace: space,
+    // We always mix in srgb, as we are approximating the color as it will be
+    // displayed on a monitor.
+    space: 'srgb',
+    outputSpace: format,
   });
 };

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,4 +1,4 @@
-import { clone, display, serialize, set, steps, to } from 'colorjs.io/fn';
+import { clone, display, mix, serialize, set, steps, to } from 'colorjs.io/fn';
 import type { PlainColorObject } from 'colorjs.io/types/src/color';
 
 import type { ColorFormatId } from '$lib/constants';
@@ -87,4 +87,22 @@ export const storeValuesToHash = (
   const bgParam = encodeColor(bg, format);
   const fgParam = encodeColor(fg, format);
   return encodeURIComponent(`${format}__${bgParam}__${fgParam}`);
+};
+
+export const premultiplyFG = ([fg, bg, format]: [
+  fg: PlainColorObject,
+  bg: PlainColorObject,
+  format: ColorFormatId,
+]) => {
+  const bgNoAlpha = clone(bg);
+  bgNoAlpha.alpha = 1;
+  const fgNoAlpha = clone(fg);
+  fgNoAlpha.alpha = 1;
+  const space = getSpaceFromFormatId(format);
+  return mix(fgNoAlpha, bgNoAlpha, 1 - fg.alpha, {
+    // Mix in oklch for more consistent adjustments
+    // This does not match https://www.w3.org/TR/compositing-1/#simplealphacompositing
+    space: 'oklch',
+    outputSpace: space,
+  });
 };

--- a/test/js/lib/components/colors/Header.spec.ts
+++ b/test/js/lib/components/colors/Header.spec.ts
@@ -11,6 +11,7 @@ describe('Header', () => {
     const { getByLabelText } = render(Header, {
       type: 'bg',
       color,
+      premultipliedFg: HSL_WHITE,
       format: 'hsl',
     });
     const input = getByLabelText('Background Color');
@@ -31,6 +32,7 @@ describe('Header', () => {
     const { getByText, getByLabelText } = render(Header, {
       type: 'fg',
       color,
+      premultipliedFg: HSL_WHITE,
       format: 'hsl',
     });
     const input = getByLabelText('Foreground Color');
@@ -55,6 +57,7 @@ describe('Header', () => {
       const { getByText, getByLabelText } = render(Header, {
         type: 'fg',
         color,
+        premultipliedFg: HSL_WHITE,
         format: 'hsl',
       });
       const input = getByLabelText('Foreground Color');
@@ -78,6 +81,7 @@ describe('Header', () => {
       const { getByLabelText } = render(Header, {
         type: 'fg',
         color,
+        premultipliedFg: HSL_WHITE,
         format: 'hsl',
       });
       const input = getByLabelText('Foreground Color');


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&bah_oklch_why)


## Description

Calculates a contrast ratio for colors with an alpha channel by mixing the color in the `srgb` space. More info on why `srgb` instead of the color's space can be found in this [comment](https://github.com/oddbird/oddcontrast/issues/91#issuecomment-1681227060).

## Steps to test/reproduce
Test contrast in different spaces with different alpha levels. 


## Show me

I added the premultiplied color below the foreground color, as it is in essence a 3rd color that is generated.

![image](https://github.com/oddbird/oddcontrast/assets/167908/a4a7a708-d0dd-4d65-ac77-fa62cf70fe74)

I've added 2 boxes that show the color as blended by your display and the result of the premultiplication mix in `srgb`. We may want to show this info somewhere, but likely not where it is.

![image](https://github.com/oddbird/oddcontrast/assets/167908/b025b76f-553f-4612-8cc6-9bd78d11c386)
