### PR TITLE
Color browser support warning breaks layout [warning-layout]

### DIFF
--- a/src/lib/components/colors/Output.svelte
+++ b/src/lib/components/colors/Output.svelte
@@ -33,7 +33,8 @@
   }
 
   li {
-    column-gap: 1ch;
+    align-items: center;
+    column-gap: 0.5ch;
     display: grid;
     grid-template-columns: auto 1fr;
   }

--- a/src/lib/components/colors/SupportWarning.svelte
+++ b/src/lib/components/colors/SupportWarning.svelte
@@ -30,3 +30,9 @@
     >
   </span>
 {/if}
+
+<style lang="scss">
+  [data-color-info~='warning'] {
+    grid-column: 1 / -1;
+  }
+</style>


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&zsdfghj)

## Description
Fixes Issue #152 


## Steps to test/reproduce
Locally, remove the `!` from line 23 in `src/lib/components/colors/SupportWarning.svelte`
This `{#if !isSupported}` becomes `{#if isSupported}`

or use an older browser like old Opera 84

## Show me

![Screenshot 2023-12-21 at 10 55 00 AM](https://github.com/oddbird/oddcontrast/assets/1581694/b66abda0-86d1-4888-95f3-ba26fcc5af3b)
