### PR TITLE
Add OSS sponsorship link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,17 @@ You can preview the production build with `yarn preview`.
 The staging site is automatically deployed via Netlify to
 <https://www.oddcontrast.com/> every time a commit is made on the `main`
 branch.
+
+_____
+## Sponsor OddBird's OSS Work
+
+At OddBird, we love contributing to the languages & tools developers rely on. 
+We're currently working on polyfills 
+for new Popover & Anchor Positioning functionality, 
+as well as CSS specifications for functions, mixins, and responsive typography. 
+Help us keep this work sustainable 
+and centered on your needs as a developer! 
+We display sponsor logos and avatars 
+on our [website](https://www.oddbird.net/oddcontrast/#what-new-features-should-oddcontrast-have%3F).
+
+[Sponsor OddBird's OSS Work](https://opencollective.com/oddbird-open-source)

--- a/README.md
+++ b/README.md
@@ -44,16 +44,17 @@ The staging site is automatically deployed via Netlify to
 <https://www.oddcontrast.com/> every time a commit is made on the `main`
 branch.
 
-_____
+---
+
 ## Sponsor OddBird's OSS Work
 
-At OddBird, we love contributing to the languages & tools developers rely on. 
-We're currently working on polyfills 
-for new Popover & Anchor Positioning functionality, 
-as well as CSS specifications for functions, mixins, and responsive typography. 
-Help us keep this work sustainable 
-and centered on your needs as a developer! 
-We display sponsor logos and avatars 
-on our [website](https://www.oddbird.net/oddcontrast/#what-new-features-should-oddcontrast-have%3F).
+At OddBird, we love contributing to the languages & tools developers rely on.
+We're currently working on polyfills
+for new Popover & Anchor Positioning functionality,
+as well as CSS specifications for functions, mixins, and responsive typography.
+Help us keep this work sustainable
+and centered on your needs as a developer!
+We display sponsor logos and avatars
+on our [website](https://www.oddbird.net/oddcontrast/#open-source-sponsors).
 
 [Sponsor OddBird's OSS Work](https://opencollective.com/oddbird-open-source)


### PR DESCRIPTION
![](https://images.unsplash.com/photo-1509886745582-64bd84c3560e?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=MnwxfDB8MXxyYW5kb218MHx8Y3V0ZSxhbmltYWwsQ0hBTkdFX018fHx8fHwxNzEzMjg4MzUy&ixlib=rb-4.0.3&q=80&utm_campaign=api-credit&utm_medium=referral&utm_source=unsplash_source&w=1080)
<!-- Swap `CHANGE_ME` for a random string to get a different image -->


## Steps to test/reproduce
- proposal to add a blurb and link to sponsor oddbird's oss work at the bottom of the OddContrast README
