### PR TITLE
Handle hashless hex

### DIFF
--- a/src/lib/components/colors/Header.svelte
+++ b/src/lib/components/colors/Header.svelte
@@ -42,8 +42,17 @@
       try {
         newColor = to(value, targetSpace, { inGamut: true });
       } catch (error) {
-        hasError = true;
-        console.error(error);
+        try {
+          // If it's possibly hex without a hash, add a hash and try again.
+          if ([3, 4, 6, 8].includes(value.length)) {
+            newColor = to(`#${value}`, targetSpace, { inGamut: true });
+          }
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        } catch (errorWithHash) {
+          hasError = true;
+          // Log original error
+          console.error(error);
+        }
       }
       if (newColor) {
         $color = newColor;

--- a/src/lib/components/colors/Header.svelte
+++ b/src/lib/components/colors/Header.svelte
@@ -46,6 +46,8 @@
           // If it's possibly hex without a hash, add a hash and try again.
           if ([3, 4, 6, 8].includes(value.length)) {
             newColor = to(`#${value}`, targetSpace, { inGamut: true });
+          } else {
+            throw error;
           }
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
         } catch (errorWithHash) {

--- a/test/lib/components/colors/Header.spec.ts
+++ b/test/lib/components/colors/Header.spec.ts
@@ -23,6 +23,40 @@ describe('Header', () => {
     expect(actual.coords).toEqual([0, 100, 50]);
   });
 
+  it('handles hex with a preceding hash', async () => {
+    const color = writable(HSL_WHITE);
+    const { getByLabelText } = render(Header, {
+      type: 'bg',
+      color,
+      format: 'hsl',
+    });
+    const input = getByLabelText('Background Color');
+    await fireEvent.focus(input);
+    await fireEvent.input(input, { target: { value: '#f00' } });
+    await fireEvent.blur(input);
+    const actual = get(color);
+
+    expect(actual.space).toEqual(HSL);
+    expect(actual.coords).toEqual([0, 100, 50]);
+  });
+
+  it('handles hex without a preceding hash', async () => {
+    const color = writable(HSL_WHITE);
+    const { getByLabelText } = render(Header, {
+      type: 'bg',
+      color,
+      format: 'hsl',
+    });
+    const input = getByLabelText('Background Color');
+    await fireEvent.focus(input);
+    await fireEvent.input(input, { target: { value: 'f00' } });
+    await fireEvent.blur(input);
+    const actual = get(color);
+
+    expect(actual.space).toEqual(HSL);
+    expect(actual.coords).toEqual([0, 100, 50]);
+  });
+
   it('shows error on invalid color', async () => {
     vi.spyOn(console, 'error').mockImplementation(() => {
       /* do nothing */


### PR DESCRIPTION
## Description
If a color input fails to parse as a color, and it has 3,4,6 and 8 characters, re-parse with a preceding `#`.

We could potentially make it a stricter check, perhaps checking all the characters are hexadecimal, or it doesn't already start with a `#`. The risks of over checking are fairly low.

## Related Issue(s)
#210 

## Steps to test/reproduce
https://deploy-preview-211--oddcontrast.netlify.app/

Type or paste in hex values without (and with) a preceding hash.