### PR TITLE
Adjust ratio for opacity

### DIFF
--- a/src/lib/components/ratio/ColorIssues.svelte
+++ b/src/lib/components/ratio/ColorIssues.svelte
@@ -54,6 +54,24 @@
         adjust the color to be in gamut.
       </p>
     </dd>
+    <dt>Background Color Alpha Values</dt>
+    <dd>
+      <p>
+        WCAG 2 contrast does not consider alpha values. Because we don't know
+        what is behind your background color, we can't estimate the contrast. If
+        the background color is not opaque, the contrast ratio is computed
+        without background or foreground opacity.
+      </p>
+    </dd>
+    <dt>Foreground Color Alpha Values</dt>
+    <dd>
+      <p>
+        WCAG 2 contrast does not consider alpha values, but we can approximate a
+        ratio by premultiplying a semi-transparent foreground color in the sRGB
+        space. In practice, the displayed foreground color may vary, depending
+        on the display and browser.
+      </p>
+    </dd>
   </dl>
 </details>
 


### PR DESCRIPTION
## Description
When foreground opacity is changed, the ratio is based on the premultiplied color. 
If the background opacity is changed, the ratio is based on both colors without any opacity.

## Related Issue(s)
#91 

## Steps to test/reproduce

