### PR TITLE
Fix ratio not updating when sliders change

### DIFF
--- a/src/lib/components/ratio/index.svelte
+++ b/src/lib/components/ratio/index.svelte
@@ -8,13 +8,13 @@
   import { bg, fg } from '$lib/stores';
 
   let fgPremultiplied = $derived.by(() => {
-    if ($fg.alpha === 1 || $bg.alpha !== 1) return $fg;
+    if ($fg.alpha === 1 || $bg.alpha !== 1) return null;
     return mix($bg, $fg, $fg.alpha, {
       space: 'srgb',
       premultiplied: false,
     });
   });
-  let ratio = $derived(contrast($bg, fgPremultiplied, 'WCAG21'));
+  let ratio = $derived(contrast($bg, fgPremultiplied ?? $fg, 'WCAG21'));
   let displayRatio = $derived(Math.round((ratio + Number.EPSILON) * 100) / 100);
   let pass = $derived(ratio >= RATIOS.AA.Normal);
   let alphaWarning = $derived.by(() => {

--- a/test/lib/components/Ratio.spec.ts
+++ b/test/lib/components/Ratio.spec.ts
@@ -1,7 +1,7 @@
-import { render } from '@testing-library/svelte';
+import { render, waitFor } from '@testing-library/svelte';
 
 import Ratio from '$lib/components/ratio/index.svelte';
-import { reset } from '$lib/stores';
+import { fg, reset } from '$lib/stores';
 
 describe('Ratio', () => {
   afterEach(() => {
@@ -14,5 +14,19 @@ describe('Ratio', () => {
     expect(getByText('7.09:1')).toBeVisible();
     expect(queryAllByText('Pass')).not.toBeNull();
     expect(queryByText('Fail')).toBeNull();
+  });
+
+  it('updates ratio when color changes', async () => {
+    const { getByText, queryByText, queryAllByText } = render(Ratio);
+    fg.update((val) => {
+      val.coords = [0.5, 0.5, 0.5];
+      return val;
+    });
+
+    await waitFor(() => {
+      expect(getByText('3.22:1')).toBeVisible();
+      expect(queryByText('Pass')).not.toBeNull();
+      expect(queryAllByText('Fail')).not.toBeNull();
+    });
   });
 });


### PR DESCRIPTION
## Description

Fixes bug where ratios were not updating on fg slider changes when bg alpha !== 1 or fg alpha === 1.

## Related Issue(s)

Closes #244 